### PR TITLE
Fix resolvers

### DIFF
--- a/dna-src/test/agent/gql_messages.js
+++ b/dna-src/test/agent/gql_messages.js
@@ -2,21 +2,21 @@ const queries = require('../queries')
 module.exports = (scenario) => {
 
 scenario.runTape('Can register a user and retrieve them again', async (t, {alice}) => {
-    let register_response = await alice.callSync("chat", "graphql", {
+    let register_response = await alice.callSync("graphql", "graphql", {
       query: queries.registerQuery,
       variables: {id: "000", name: "wollum", avatarUrl: "//"}
     })
     console.log(register_response)
 
     // add a thread
-    const add_result = await alice.callSync("chat", "graphql", {
+    const add_result = await alice.callSync("graphql", "graphql", {
       query: queries.findOrCreateThreadQuery,
       variables: {participantIds: []}
     })
     let threadId = JSON.parse(add_result.Ok).findOrCreateThread.id
     t.equal(threadId.length, 46) // thread was created and hash returned
 
-    const post_result = await alice.callSync("chat", "graphql", {
+    const post_result = await alice.callSync("graphql", "graphql", {
       query: queries.createMessageQuery,
       variables: {messageThreadId: threadId, text: "Hello hylo+holo!"}
     })
@@ -24,15 +24,15 @@ scenario.runTape('Can register a user and retrieve them again', async (t, {alice
     // t.notEqual(JSON.parse(post_result.Ok).createMessage.text, "Hello hylo+holo!")
 
     // retrieve message from channel
-    await alice.callSync("chat", "graphql", {
+    await alice.callSync("graphql", "graphql", {
       query: queries.getMessagesQuery,
       variables: {id: threadId, cursor: "0"}
     })
-    await alice.callSync("chat", "graphql", {
+    await alice.callSync("graphql", "graphql", {
       query: queries.getMessagesQuery,
       variables: {id: threadId, cursor: "0"}
     })
-    const get_result = await alice.callSync("chat", "graphql", {
+    const get_result = await alice.callSync("graphql", "graphql", {
       query: queries.getMessagesQuery,
       variables: {id: threadId, cursor: "0"}
     })

--- a/dna-src/test/index.js
+++ b/dna-src/test/index.js
@@ -9,6 +9,7 @@ const scenario = new Scenario([instanceAlice], { debugLog: true })
 
 // require('./agent/register')(scenario)
 // require('./agent/threads')(scenario)
-require('./agent/gql_threads')(scenario)
-
 // require('./agent/messages')(scenario)
+
+require('./agent/gql_threads')(scenario)
+require('./agent/gql_messages')(scenario)

--- a/dna-src/zomes/graphql/code/Cargo.toml
+++ b/dna-src/zomes/graphql/code/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 juniper = "0.11.1"
 derive_more = "0.9.0"
+cached = "0.8.0"
 hdk = { git = "https://github.com/holochain/holochain-rust" , tag = "v0.0.7-alpha" }
 holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust" , tag = "v0.0.7-alpha" }
 holochain_core_types_derive = { git = "https://github.com/holochain/holochain-rust" , tag = "v0.0.7-alpha" }

--- a/dna-src/zomes/graphql/code/src/lib.rs
+++ b/dna-src/zomes/graphql/code/src/lib.rs
@@ -15,6 +15,7 @@ extern crate holochain_core_types_derive;
 extern crate juniper;
 #[macro_use]
 extern crate derive_more;
+#[macro_use] extern crate cached;
 
 use hdk::{
     error::{ZomeApiError, ZomeApiResult},

--- a/dna-src/zomes/graphql/code/src/schema/me.rs
+++ b/dna-src/zomes/graphql/code/src/schema/me.rs
@@ -23,10 +23,6 @@ graphql_object!(Me: Context |&self| {
 	}
 
 	field messageThreads(&executor, first: Option<i32>, offset: Option<i32>, order: Option<String>, sort_by: Option<String>) -> FieldResult<MessageThreadQuerySet> {
-		// Ok(MessageThreadQuerySet{
-		// 	total: 0,
-		// 	items: Vec::new()
-		// })
 		let result = call_cached("chat", "get_my_threads", json!({}).into())?;
 		let result_vec = result.as_array().unwrap();
 		Ok(MessageThreadQuerySet{

--- a/dna-src/zomes/graphql/code/src/schema/message_thread.rs
+++ b/dna-src/zomes/graphql/code/src/schema/message_thread.rs
@@ -52,17 +52,15 @@ graphql_object!(MessageThread: Context |&self| {
   }
 
   field messages(&executor, first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<MessageQuerySet> {
-  	// let message_ids = thread::get_thread_messages(executor.context().cache.borrow_mut(), &self.id.to_string().into())?;
-   //    Ok(MessageQuerySet{
-   //    	total: message_ids.len() as i32,
-   //    	items: message_ids.into_iter().map(|id| Message{
-   //    		id: id.into(),
-   //    	}).collect()
-   //    })
+  	let result = call_cached("chat", "get_thread_messages", json!({"thread_addr": self.id.to_string()}).into())?;
+    let message_ids: Vec<serde_json::Value> = result.as_array().unwrap().to_vec();
+
     Ok(MessageQuerySet{
-      total: 0,
-      items: Vec::new()
-    }) 
+    	total: message_ids.len() as i32,
+    	items: message_ids.into_iter().map(|id| Message{
+    		id: id.as_str().unwrap().to_string().into(),
+    	}).collect()
+    })
   }
 
   field unreadCount(&executor) -> i32 {

--- a/dna-src/zomes/graphql/code/src/schema/mod.rs
+++ b/dna-src/zomes/graphql/code/src/schema/mod.rs
@@ -119,18 +119,14 @@ pub struct Mutation;
 graphql_object!(Mutation: Context |&self| {
 
     field createMessage(&executor, data: MessageInput) -> FieldResult<Message> {
-    	// let id = post_message_to_thread(
-     //        executor.context().cache.borrow_mut(),
-    	// 	&data.message_thread_id.unwrap_or("".into()).into(),
-    	// 	data.text.unwrap_or("".into()),
-     //        data.created_at.unwrap_or("".into()),
-    	// )?;
-    	// Ok(Message{
-    	// 	id: id.into(),
-    	// })
-        Ok(Message{
-            id: "".to_string().into()
-        })
+        let id = call_cached("chat", "post_message_to_thread", json!({
+            "thread_addr": data.message_thread_id.unwrap(),
+            "text": data.text.unwrap_or("".into()),
+            "timestamp": data.created_at.unwrap_or("".into())
+        }).into())?;
+    	Ok(Message{
+    		id: id.as_str().unwrap().to_string().into()
+    	})
     }
 
     field findOrCreateThread(&executor, data: MessageThreadInput) -> FieldResult<MessageThread> {


### PR DESCRIPTION
This gets us back to the level of functionality we had before the refactor into multiple zomes.

- Now uses `cached!` macro instead of holochain cache
- schema lives in a single zome which is the only entry point for the UI
- Ready for new DNAs to be added!