### PR TITLE
Add back a 2nd valid test agent and default to pickle store

### DIFF
--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -5,6 +5,12 @@ name = "HoloTester1"
 public_address = "HcSCjdUIsn6Botxcf8bwmQFDqMz6aqctojcPhzNi54B39cbwJFIuKNjP9uambii"
 keystore_file = "./agent1.keystore"
 
+# [[agents]]
+# id = "test_agent2"
+# name = "HoloTester2"
+# public_address = "HcSCJC97Yu987nhupguu3vBF3HHVtbu4m7rZpgGF7qWwiiink586Ih539kHns7r"
+# keystore_file = "./agent2.keystore"
+
 [[dnas]]
 id = "chat_dna"
 file = "./dna/hylo.dna.json"
@@ -18,7 +24,7 @@ agent = "test_agent1"
 type = "simple"
 file = "app_spec.log"
 [instances.storage]
-type = "file"
+type = "pickle"
 path = "tmp-storage"
 
 [[interfaces]]


### PR DESCRIPTION
It might be useful for future tests over networking to have at least 3 pre-build test agents. I only had this second one around and don't have the instructions for generating more. 