### PR TITLE
Adds test to enforce the schema matches the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ If you plan to develop the DNA code further the automated tests can be run using
 
 At the current time the container config does not include configuration of the network. This is because at the time of writing you must hard code the IPs in the local network. Defauls about this can be found at [developer.holochain](https://developer.holochain.org/start.html) and will likely be updated soon.
 
+## Making changes to the schema
+
+The `schema.graphql` documents the specification of the schema that this DNA must implement. This is enforced via the automated tests.
+
+Any changes to the `schema.graphql` file must be approved by the frond-end dev team to ensure no unplanned breaking changes.
+
 ## Example queries
 Handy to have these here for reference. These are the 4 queries that are redirected to holochain.
 

--- a/dna-src/test/agent/community.js
+++ b/dna-src/test/agent/community.js
@@ -2,7 +2,6 @@ module.exports = (scenario) => {
 
   scenario.runTape("Create and get single community", async (t, { alice }) => {
     const add_community_result = await alice.callSync("community", "create_community", {
-      base: "Network 1",
       name: "Test Community 1",
       slug: "url/slug1"
     })
@@ -17,7 +16,6 @@ module.exports = (scenario) => {
     t.equal(get_community_result.Ok.name, "Test Community 1")
 
     const get_communitys_result = await alice.callSync("community", "get_communitys", {
-      base: "Network 1"
     })
     console.log(get_communitys_result)
     t.deepEqual(get_communitys_result.Ok, [address], "Could retrieve the added community from the base")

--- a/dna-src/test/agent/community.js
+++ b/dna-src/test/agent/community.js
@@ -15,6 +15,12 @@ module.exports = (scenario) => {
     console.log(get_community_result)
     t.equal(get_community_result.Ok.name, "Test Community 1")
 
+    const get_community_result_by_slug = await alice.callSync("community", "get_community_address_by_slug", {
+      slug: "url/slug1"
+    })
+    console.log(get_community_result_by_slug)
+    t.equal(get_community_result_by_slug.Ok, address)
+
     const get_communitys_result = await alice.callSync("community", "get_communitys", {
     })
     console.log(get_communitys_result)

--- a/dna-src/test/agent/gql_communitys.js
+++ b/dna-src/test/agent/gql_communitys.js
@@ -31,6 +31,16 @@ module.exports = (scenario) => {
     let communityName = JSON.parse(getResult.Ok).community.name
     t.equal(communityName, "new graphql community") // thread was created and hash returned
 
+
+    // retrieve community by slug
+    const getResultSlug = await alice.callSync("graphql", "graphql", {
+      query: queries.getCommunityQuery,
+      variables: {slug}
+    })
+    console.log(getResultSlug)
+    let communityNameSlug = JSON.parse(getResultSlug.Ok).community.name
+    t.equal(communityNameSlug, "new graphql community") // thread was created and hash returned
+
     // add a post with the community as the base
     const addPostResult = await alice.callSync("graphql", "graphql", {
       query: queries.createPostQuery,

--- a/dna-src/test/agent/gql_communitys.js
+++ b/dna-src/test/agent/gql_communitys.js
@@ -14,7 +14,6 @@ module.exports = (scenario) => {
     const addResult = await alice.callSync("graphql", "graphql", {
       query: queries.createCommunityQuery,
       variables: {
-        base: "a base string to link from",
         name: "new graphql community",
         slug
       }
@@ -36,7 +35,7 @@ module.exports = (scenario) => {
     const addPostResult = await alice.callSync("graphql", "graphql", {
       query: queries.createPostQuery,
       variables: {
-        base: slug,
+        communitySlug: slug,
         title: "new post 3000",
         details: "this is a details string",
         type: "a type"

--- a/dna-src/test/agent/gql_posts.js
+++ b/dna-src/test/agent/gql_posts.js
@@ -12,7 +12,7 @@ scenario.runTape('Can create a new post', async (t, {alice}) => {
     const addResult = await alice.callSync("graphql", "graphql", {
       query: queries.createPostQuery,
       variables: {
-        base: "base to link from",
+        communitySlug: "base to link from",
         title: "new post",
         details: "this is a details string",
         type: "a type"

--- a/dna-src/test/index.js
+++ b/dna-src/test/index.js
@@ -28,14 +28,7 @@ singleAgentScenario.runTape('Reference GraphQL schema matches the implementation
 	const implSchemaDef = JSON.parse(getSchemaResult.Ok)
 	const implSchema = buildClientSchema(implSchemaDef)
 
-	const diffs = referenceSchema.diff(implSchema).filter(d => {
-		// dont worry about description diffs and backward compatible changes
-		return (
-			d.diffType !== 'FieldDescriptionDiff' && 
-			d.diffType !== 'TypeDescriptionDiff' && 
-			!d.backwardsCompatible
-		)
-	});
+	const diffs = referenceSchema.diff(implSchema).filter(d => !d.backwardsCompatible)
 
 	if(diffs.length > 0) {
 		console.log(diffs)

--- a/dna-src/test/index.js
+++ b/dna-src/test/index.js
@@ -25,13 +25,16 @@ singleAgentScenario.runTape('Reference GraphQL schema matches the implementation
 	  	query: introspectionQuery,
 		variables: {}
 	})
-	console.log(getSchemaResult)
 	const implSchemaDef = JSON.parse(getSchemaResult.Ok)
 	const implSchema = buildClientSchema(implSchemaDef)
 
 	const diffs = referenceSchema.diff(implSchema).filter(d => {
-		// dont worry about description diffs
-		return d.diffType !== 'FieldDescriptionDiff'
+		// dont worry about description diffs and backward compatible changes
+		return (
+			d.diffType !== 'FieldDescriptionDiff' && 
+			d.diffType !== 'TypeDescriptionDiff' && 
+			!d.backwardsCompatible
+		)
 	});
 
 	if(diffs.length > 0) {
@@ -42,19 +45,17 @@ singleAgentScenario.runTape('Reference GraphQL schema matches the implementation
 })
 
 
+require('./agent/register')(singleAgentScenario)
+require('./agent/threads')(singleAgentScenario)
+require('./agent/messages')(singleAgentScenario)
+require('./agent/comments')(singleAgentScenario)
+require('./agent/posts')(singleAgentScenario)
+require('./agent/community')(singleAgentScenario)
 
+require('./agent/gql_comments')(singleAgentScenario)
+require('./agent/gql_threads')(singleAgentScenario)
+require('./agent/gql_messages')(singleAgentScenario)
+require('./agent/gql_posts')(singleAgentScenario)
+require('./agent/gql_communitys')(singleAgentScenario)
 
-// require('./agent/register')(singleAgentScenario)
-// require('./agent/threads')(singleAgentScenario)
-// require('./agent/messages')(singleAgentScenario)
-// require('./agent/comments')(singleAgentScenario)
-// require('./agent/posts')(singleAgentScenario)
-// require('./agent/community')(singleAgentScenario)
-
-// require('./agent/gql_comments')(singleAgentScenario)
-// require('./agent/gql_threads')(singleAgentScenario)
-// require('./agent/gql_messages')(singleAgentScenario)
-// require('./agent/gql_posts')(singleAgentScenario)
-// require('./agent/gql_communitys')(singleAgentScenario)
-
-// require('./scenarios/retrieve_agents_people_query')(twoAgentScenario)
+require('./scenarios/retrieve_agents_people_query')(twoAgentScenario)

--- a/dna-src/test/package.json
+++ b/dna-src/test/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "@holochain/holochain-nodejs": "0.4.10-alpha1",
+    "graphql": "^14.2.1",
+    "graphql-schema-utils": "^0.6.7",
     "json3": "*",
     "tape": "^4.9.1"
   }

--- a/dna-src/test/queries.js
+++ b/dna-src/test/queries.js
@@ -235,8 +235,8 @@ mutation (
 `
 
 module.exports.getCommunityQuery = `
-query ($id: ID) {
-  community(id: $id) {
+query ($id: ID, $slug: String) {
+  community(id: $id, slug: $slug) {
     id
     name
   }

--- a/dna-src/test/queries.js
+++ b/dna-src/test/queries.js
@@ -7,8 +7,8 @@ mutation ($id: ID, $name: String, $avatarUrl: String) {
 `
 
 module.exports.getPeopleQuery = `
-query PeopleContacts ($first: Int) {
-  people (first: $first) {
+query PeopleContacts {
+  people {
     items {
       id
       name
@@ -26,16 +26,14 @@ query PeopleContacts ($first: Int) {
 `
 
 module.exports.getMessageThreadsQuery = `
-query ($first: Int, $offset: Int) {
+query {
   me {
     id
-    messageThreads(sortBy: "updatedAt", order: "desc", first: $first, offset: $offset) {
+    messageThreads {
       total
       hasMore
       items {
         id
-        unreadCount
-        lastReadAt
         createdAt
         updatedAt
         participants {
@@ -43,7 +41,7 @@ query ($first: Int, $offset: Int) {
           name
           avatarUrl
         }
-        messages(first: 1, order: "desc") {
+        messages {
           items {
             id
             createdAt
@@ -89,10 +87,10 @@ mutation ($messageThreadId: String, $text: String) {
 }`
 
 module.exports.getMessagesQuery = `
-  query ($id: ID, $cursor: ID) {
+  query ($id: ID) {
     messageThread (id: $id) {
       id
-      messages(first: 80, cursor: $cursor, order: "desc") {
+      messages {
         items {
           id
           createdAt
@@ -127,10 +125,10 @@ mutation ($postId: String, $text: String) {
 `
 
 module.exports.getCommentsQuery = `
-query ($id: ID, $cursor: ID) {
+query ($id: ID) {
     post(id: $id) {
       id
-      comments(first: 10, cursor: $cursor, order: "desc") {
+      comments {
         items {
           id
           text
@@ -154,13 +152,13 @@ query ($id: ID, $cursor: ID) {
 
 module.exports.createPostQuery = `
 mutation (
-  $base: String,
+  $communitySlug: String,
   $type: String,
   $title: String,
   $details: String
 ) {
   createPost(data: {
-    base: $base,
+    communitySlug: $communitySlug,
     type: $type,
     title: $title,
     details: $details
@@ -200,8 +198,8 @@ query ($id: ID) {
 
 
 module.exports.getPostsQuery = `
-query (  $sortBy: String,  $offset: Int,  $search: String,  $filter: String,  $topic: ID,  $first: Int) {
-  posts(  first: $first,  offset: $offset,  sortBy: $sortBy,  search: $search,  filter: $filter,  topic: $topic,  order: "desc") {
+query {
+  posts {
     hasMore
     items {
       id
@@ -222,12 +220,10 @@ query (  $sortBy: String,  $offset: Int,  $search: String,  $filter: String,  $t
 
 module.exports.createCommunityQuery =`
 mutation (
-  $base: String,
   $name: String,
   $slug: String
 ) {
   createCommunity(data: {
-    base: $base,
     name: $name,
     slug: $slug
   })

--- a/dna-src/zomes/community/code/src/community/mod.rs
+++ b/dna-src/zomes/community/code/src/community/mod.rs
@@ -29,9 +29,9 @@ pub fn get_community(address: Address) -> ZomeApiResult<Community> {
     utils::get_as_type(address)
 }
 
-pub fn create_community(base: String, name: String, slug: String) -> ZomeApiResult<Address> {
+pub fn create_community(name: String, slug: String) -> ZomeApiResult<Address> {
 
-    let base_entry = Entry::App(COMMUNITY_BASE_ENTRY.into(), RawString::from(base).into());
+    let base_entry = Entry::App(COMMUNITY_BASE_ENTRY.into(), RawString::from("communities_base").into());
     let base_address = hdk::commit_entry(&base_entry)?;
 
     let community_address = hdk::commit_entry(
@@ -54,8 +54,8 @@ pub fn create_community(base: String, name: String, slug: String) -> ZomeApiResu
     Ok(community_address)
 }
 
-pub fn get_communitys(base: String) -> ZomeApiResult<Vec<Address>> {
-    let address = hdk::entry_address(&Entry::App(COMMUNITY_BASE_ENTRY.into(), RawString::from(base).into()))?;
+pub fn get_communitys() -> ZomeApiResult<Vec<Address>> {
+    let address = hdk::entry_address(&Entry::App(COMMUNITY_BASE_ENTRY.into(), RawString::from("communities_base").into()))?;
     Ok(hdk::get_links(&address, COMMUNITY_LINK_TAG)?.addresses().to_vec())
 }
 

--- a/dna-src/zomes/community/code/src/lib.rs
+++ b/dna-src/zomes/community/code/src/lib.rs
@@ -34,6 +34,11 @@ define_zome! {
             outputs: |result: ZomeApiResult<community::Community>|,
             handler: community::get_community
         }
+        get_community_address_by_slug: {
+            inputs: |slug: String|,
+            outputs: |result: ZomeApiResult<Address>|,
+            handler: community::get_community_address_by_slug
+        }
         create_community: {
             inputs: |name: String, slug: String|,
             outputs: |result: ZomeApiResult<Address>|,
@@ -50,7 +55,8 @@ define_zome! {
         hc_public [
             get_community,
             create_community,
-            get_communitys
+            get_communitys,
+            get_community_address_by_slug
         ]
     }
 }

--- a/dna-src/zomes/community/code/src/lib.rs
+++ b/dna-src/zomes/community/code/src/lib.rs
@@ -35,12 +35,12 @@ define_zome! {
             handler: community::get_community
         }
         create_community: {
-            inputs: |base: String, name: String, slug: String|,
+            inputs: |name: String, slug: String|,
             outputs: |result: ZomeApiResult<Address>|,
             handler: community::create_community
         }
         get_communitys: {
-            inputs: |base: String|,
+            inputs: | |,
             outputs: |result: ZomeApiResult<Vec<Address>>|,
             handler: community::get_communitys
         }

--- a/dna-src/zomes/graphql/code/src/schema/comment.rs
+++ b/dna-src/zomes/graphql/code/src/schema/comment.rs
@@ -36,33 +36,33 @@ impl Comment {
 }
 
 graphql_object!(Comment: Context |&self| {
-    field id(&executor) -> ID {
+    field id() -> ID {
     	self.id.clone().into()
     }
 
-    field creator(&executor) -> FieldResult<Person> {
+    field creator() -> FieldResult<Person> {
     	let id: String = self.retrieve_entry()?.creator;
     	Ok(Person{id: id.into()})
     }
 
-    field createdAt(&executor) -> FieldResult<String> {
+    field createdAt() -> FieldResult<String> {
       Ok(self.retrieve_entry()?.timestamp)
     }
 
-    field createdFrom(&executor) -> String {
+    field createdFrom() -> String {
     	"createdFrom".into()
     }
 
-    field text(&executor) -> FieldResult<String> {
+    field text() -> FieldResult<String> {
     	Ok(self.retrieve_entry()?.text)
     }
 
-    field post(&executor) -> FieldResult<Post> {
+    field post() -> FieldResult<Post> {
     	let id: String = self.retrieve_entry()?.base;
     	Ok(Post{id: id.into()})
     }
 
-    field attachments(&executor) -> FieldResult<Vec<Attachment>> {
+    field attachments() -> FieldResult<Vec<Attachment>> {
       Ok(Vec::new())
     }
 });
@@ -82,15 +82,15 @@ pub struct CommentQuerySet {
     pub items: Vec<Comment>,
 }
 graphql_object!(CommentQuerySet: Context |&self| {
-  field total(&executor) -> i32 {
+  field total() -> i32 {
     self.total
   }
 
-  field hasMore(&executor) -> bool {
+  field hasMore() -> bool {
     false
   }
 
-  field items(&executor) -> Option<Vec<Option<Comment>>> {
+  field items() -> Option<Vec<Option<Comment>>> {
     Some(self.items.iter().map(|item| Some(item.clone())).collect())
   }
 });

--- a/dna-src/zomes/graphql/code/src/schema/me.rs
+++ b/dna-src/zomes/graphql/code/src/schema/me.rs
@@ -18,11 +18,11 @@ type Me {
 */
 pub struct Me;
 graphql_object!(Me: Context |&self| {
-	field id(&executor) -> FieldResult<ID> {
+	field id() -> FieldResult<ID> {
 		Ok(identity::get_identity(AGENT_ADDRESS.to_string().into())?.hylo_id.into())
 	}
 
-	field messageThreads(&executor, first: Option<i32>, offset: Option<i32>, order: Option<String>, sort_by: Option<String>) -> FieldResult<MessageThreadQuerySet> {
+	field messageThreads(first: Option<i32>, offset: Option<i32>, order: Option<String>, sort_by: Option<String>) -> FieldResult<MessageThreadQuerySet> {
 		let result = call_cached("chat", "get_my_threads", json!({}).into())?;
 		let result_vec = result.as_array().unwrap();
 		Ok(MessageThreadQuerySet{

--- a/dna-src/zomes/graphql/code/src/schema/message.rs
+++ b/dna-src/zomes/graphql/code/src/schema/message.rs
@@ -35,24 +35,24 @@ impl Message {
 }
 
 graphql_object!(Message: Context |&self| {
-	field id(&executor) -> ID {
+	field id() -> ID {
 		self.id.clone().into()
 	}
 
-	field text(&executor) -> FieldResult<String> {
+	field text() -> FieldResult<String> {
 		Ok(self.retrieve_entry()?.text)
 	}
 
-	field creator(&executor) -> FieldResult<Person> {
+	field creator() -> FieldResult<Person> {
 		let id: String = self.retrieve_entry()?.creator;
 		Ok(Person{id: id.into()})
 	}
 
-	field messageThread(&executor) -> FieldResult<MessageThread> {
+	field messageThread() -> FieldResult<MessageThread> {
 		Ok(MessageThread{id: self.retrieve_entry()?.thread_id.into()})
 	}
 
-	field createdAt(&executor) -> String {
+	field createdAt() -> String {
 		"2019-01-14T07:52:22+0000".into()
 	}
 });
@@ -71,15 +71,15 @@ pub struct MessageQuerySet {
 }
 
 graphql_object!(MessageQuerySet: Context |&self| {
-	field total(&executor) -> i32 {
+	field total() -> i32 {
 		self.total
 	}
 
-	field hasMore(&executor) -> bool {
+	field hasMore() -> bool {
 		false
 	}
 
-	field items(&executor) -> Option<Vec<Option<Message>>> {
+	field items() -> Option<Vec<Option<Message>>> {
 		Some(self.items.iter().map(|item| Some(item.clone())).collect())
 	}
 });

--- a/dna-src/zomes/graphql/code/src/schema/message_thread.rs
+++ b/dna-src/zomes/graphql/code/src/schema/message_thread.rs
@@ -12,37 +12,25 @@ use super::person::Person;
 use super::message::{Message, MessageQuerySet};
 
 
-/*
-type MessageThread {
-  id: ID
-  createdAt: String
-  updatedAt: String
-  participants(first: i32, cursor: ID, order: String): [Person]
-  participantsTotal: Int
-  messages(first: Int, cursor: ID, order: String): MessageQuerySet
-  unreadCount: Int
-  lastReadAt: String
-}
-*/
 #[derive(Constructor, Clone)]
 pub struct MessageThread {
     pub id: HID,
 }
 
 graphql_object!(MessageThread: Context |&self| {
-	field id(&executor) -> ID {
+	field id() -> ID {
 		self.id.clone().into()
 	}
 
-	field createdAt(&executor) -> String {
+	field createdAt() -> String {
 		"2019-01-14T07:52:22+0000".into()
 	}
 
-	field updatedAt(&executor) -> String {
+	field updatedAt() -> String {
 		"2019-01-14T07:52:22+0000".into()
 	}
 
-  field participants(&executor, first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<Vec<Option<Person>>> {
+  field participants(first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<Vec<Option<Person>>> {
       let result = call_cached("chat", "get_thread_participants", json!({"thread_addr": self.id.to_string()}).into())?;
       let person_ids: Vec<serde_json::Value> = result.as_array().unwrap().to_vec();
 
@@ -51,7 +39,12 @@ graphql_object!(MessageThread: Context |&self| {
       })).collect())
   }
 
-  field messages(&executor, first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<MessageQuerySet> {
+  field participantsTotal() -> FieldResult<i32> {
+    let result = call_cached("chat", "get_thread_participants", json!({"thread_addr": self.id.to_string()}).into())?;
+    Ok(result.as_array().unwrap().to_vec().len() as i32)
+  }
+
+  field messages(first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<MessageQuerySet> {
   	let result = call_cached("chat", "get_thread_messages", json!({"thread_addr": self.id.to_string()}).into())?;
     let message_ids: Vec<serde_json::Value> = result.as_array().unwrap().to_vec();
 
@@ -63,11 +56,11 @@ graphql_object!(MessageThread: Context |&self| {
     })
   }
 
-  field unreadCount(&executor) -> i32 {
+  field unreadCount() -> i32 {
   	0
   }
 
-  field lastReadAt(&executor) -> String {
+  field lastReadAt() -> String {
 	"".into()
   }
 });
@@ -87,15 +80,15 @@ pub struct MessageThreadQuerySet {
     pub items: Vec<MessageThread>,
 }
 graphql_object!(MessageThreadQuerySet: Context |&self| {
-  field total(&executor) -> i32 {
+  field total() -> i32 {
     self.total
   }
 
-  field hasMore(&executor) -> bool {
+  field hasMore() -> bool {
     false
   }
 
-  field items(&executor) -> Option<Vec<Option<MessageThread>>> {
+  field items() -> Option<Vec<Option<MessageThread>>> {
     Some(self.items.iter().map(|item| Some(item.clone())).collect())
   }
 });

--- a/dna-src/zomes/graphql/code/src/schema/mod.rs
+++ b/dna-src/zomes/graphql/code/src/schema/mod.rs
@@ -112,10 +112,22 @@ graphql_object!(Query: Context |&self| {
 
     field community(id: Option<ID>, slug: Option<String>) -> FieldResult<Community> {
         // TODO: look up community by slug optionally
+        let id: Option<ID> = match slug {
+            Some(slug) => {
+                let address = call_cached("community", "get_community_address_by_slug", 
+                    json!({
+                        "slug": slug,
+                    }).into())?;
+                Some(address.as_str().unwrap().to_string().into())
+            },
+            None => id
+        };
+
         match id {
             Some(id) => Ok(Community{id: id.into()}),
-            None => Err(FieldError::new("Must call with an id parameter", Value::Null))
+            None => Err(FieldError::new("Must call with either an id parameter or a slug", Value::Null))
         }
+
     }
 
     field post(id: Option<ID>) -> FieldResult<Post> {

--- a/dna-src/zomes/graphql/code/src/schema/mod.rs
+++ b/dna-src/zomes/graphql/code/src/schema/mod.rs
@@ -46,16 +46,15 @@ struct CommentInput {
 
 #[derive(GraphQLInputObject)]
 struct PostInput {
-    #[graphql(name="type", description="The latitude")]
-    r#type: Option<String>,
-    base: Option<String>,
     title: Option<String>,
-    details: Option<String>
+    details: Option<String>,
+    #[graphql(name="type", description="The post type")]
+    r#type: Option<String>,
+    community_slug: Option<String>
 }
 
 #[derive(GraphQLInputObject)]
 struct CommunityInput {
-    base: Option<String>,
     name: Option<String>,
 	slug: Option<String>
 }
@@ -70,15 +69,15 @@ struct CommunityInput {
 pub struct Query;
 graphql_object!(Query: Context |&self| {
 
-    field apiVersion(&executor) -> FieldResult<String> {
+    field apiVersion() -> FieldResult<String> {
         Ok("0.0.1".to_string())
     }
 
-    field me(&executor) -> FieldResult<Me> {
+    field me() -> FieldResult<Me> {
     	Ok(Me)
     }
 
-    field messageThread(&executor, id: Option<ID>) -> FieldResult<MessageThread> {
+    field messageThread(id: Option<ID>) -> FieldResult<MessageThread> {
     	match id {
     		Some(id) => Ok(MessageThread{id: id.into()}),
     		None => Err(FieldError::new("Must call with an id parameter", Value::Null))
@@ -111,21 +110,29 @@ graphql_object!(Query: Context |&self| {
     	)
 	}
 
-    field community(&executor, id: Option<ID>) -> FieldResult<Community> {
+    field community(id: Option<ID>, slug: Option<String>) -> FieldResult<Community> {
+        // TODO: look up community by slug optionally
         match id {
             Some(id) => Ok(Community{id: id.into()}),
             None => Err(FieldError::new("Must call with an id parameter", Value::Null))
         }
     }
 
-    field post(&executor, id: Option<ID>) -> FieldResult<Post> {
+    field post(id: Option<ID>) -> FieldResult<Post> {
         match id {
             Some(id) => Ok(Post{id: id.into()}),
             None => Err(FieldError::new("Must call with an id parameter", Value::Null))
         }
     }
 
-    field comment(&executor, id: Option<ID>) -> FieldResult<Comment> {
+    field person(id: Option<ID>) -> FieldResult<Person> {
+        match id {
+            Some(id) => Ok(Person{id: id.into()}),
+            None => Err(FieldError::new("Must call with an id parameter", Value::Null))
+        }
+    }
+
+    field comment(id: Option<ID>) -> FieldResult<Comment> {
         match id {
             Some(id) => Ok(Comment{id: id.into()}),
             None => Err(FieldError::new("Must call with an id parameter", Value::Null))
@@ -140,15 +147,14 @@ graphql_object!(Query: Context |&self| {
  */
 
  #[derive(GraphQLObject)]
-struct Success {
+struct GenericResult {
     success: bool,
-    data: String,
 }
-impl Success {
-    pub fn new(data: String) -> Self {
-        Success{
+
+impl GenericResult {
+    pub fn new() -> Self {
+        GenericResult{
             success: true,
-            data,
         }
     }
 }
@@ -157,7 +163,8 @@ impl Success {
 pub struct Mutation;
 graphql_object!(Mutation: Context |&self| {
 
-    field createMessage(&executor, data: MessageInput) -> FieldResult<Message> {
+    field createMessage(data: Option<MessageInput>) -> FieldResult<Message> {
+        let data = data.unwrap();
         let id = call_cached("chat", "post_message_to_thread", json!({
             "thread_addr": data.message_thread_id.unwrap(),
             "text": data.text.unwrap_or("".into()),
@@ -168,8 +175,8 @@ graphql_object!(Mutation: Context |&self| {
     	})
     }
 
-    field findOrCreateThread(&executor, data: MessageThreadInput) -> FieldResult<MessageThread> {
-    	let participant_hylo_ids: Vec<String> = data.participant_ids.unwrap().into_iter().map(|elem| elem.unwrap()).collect();
+    field findOrCreateThread(data: Option<MessageThreadInput>) -> FieldResult<MessageThread> {
+    	let participant_hylo_ids: Vec<String> = data.unwrap().participant_ids.unwrap().into_iter().map(|elem| elem.unwrap()).collect();
 
         let participant_agent_ids = participant_hylo_ids
             .iter()
@@ -184,16 +191,17 @@ graphql_object!(Mutation: Context |&self| {
         })
     }
 
-    field registerUser(id: Option<ID>, name: Option<String>, avatar_url: Option<String>) -> FieldResult<Success> {
+    field registerUser(id: Option<ID>, name: Option<String>, avatar_url: Option<String>) -> FieldResult<GenericResult> {
     	let id = identity::register_user(
     		name.unwrap_or("?".into()),
     		avatar_url.unwrap_or("".into()),
     		id.unwrap_or(juniper::ID::new("")).to_string(),
     	)?;
-    	Ok(Success::new(id.to_string()))
+    	Ok(GenericResult::new())
     }
 
-    field createComment(&executor, data: CommentInput) -> FieldResult<Comment> {
+    field createComment(data: Option<CommentInput>) -> FieldResult<Comment> {
+        let data = data.unwrap();
         let id = call_cached("comments", "create_comment", json!({
             "comment": {
                 "base": data.post_id.unwrap(),
@@ -206,10 +214,11 @@ graphql_object!(Mutation: Context |&self| {
     	})
     }
 
-    field createPost(&executor, data: PostInput) -> FieldResult<Post> {
+    field createPost(data: Option<PostInput>) -> FieldResult<Post> {
+        let data = data.unwrap();
         let id = call_cached("posts", "create_post", json!(
             {
-                "base": data.base.unwrap(),
+                "base": data.community_slug.unwrap(),
                 "post_type": data.r#type.unwrap(),
                 "title": data.title.unwrap(),
                 "details": data.details.unwrap_or("".into()),
@@ -223,10 +232,10 @@ graphql_object!(Mutation: Context |&self| {
         })
     }
 
-    field createCommunity(&executor, data: CommunityInput) -> FieldResult<Community> {
+    field createCommunity(data: Option<CommunityInput>) -> FieldResult<Community> {
+        let data = data.unwrap();
         let id = call_cached("community", "create_community", json!(
             {
-                "base": data.base.unwrap(),
                 "name": data.name.unwrap_or("".into()),
                 "slug": data.slug.unwrap_or("".into())
             }

--- a/dna-src/zomes/graphql/code/src/schema/person.rs
+++ b/dna-src/zomes/graphql/code/src/schema/person.rs
@@ -17,20 +17,20 @@ pub struct Person {
     pub id: HID,
 }
 graphql_object!(Person: Context |&self| {
-	field id(&executor) -> FieldResult<ID> {
+	field id() -> FieldResult<ID> {
 		// be careful. This field is the Hylo ID not the holochain ID
 		Ok(identity::get_identity(self.id.to_string().into())?.hylo_id.into())
 	}
 
-	field name(&executor) -> FieldResult<String> {
+	field name() -> FieldResult<String> {
 		Ok(identity::get_identity(self.id.to_string().into())?.name)
 	}
 
-	field avatarUrl(&executor) -> FieldResult<String> {
+	field avatarUrl() -> FieldResult<String> {
 		Ok(identity::get_identity(self.id.to_string().into())?.avatar_url)
 	}
 
-	field memberships(&executor, first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<Vec<Membership>> {
+	field memberships(first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<Vec<Membership>> {
 		Ok(Vec::new())
 	}
 });
@@ -49,15 +49,15 @@ pub struct PersonQuerySet {
     pub items: Vec<Person>,
 }
 graphql_object!(PersonQuerySet: Context |&self| {
-	field total(&executor) -> i32 {
+	field total() -> i32 {
 		self.total
 	}
 
-	field hasMore(&executor) -> bool {
+	field hasMore() -> bool {
 		false
 	}
 
-	field items(&executor) -> Option<Vec<Option<Person>>> {
+	field items() -> Option<Vec<Option<Person>>> {
 		Some(self.items.iter().map(|item| Some(item.clone())).collect())
 	}
 });

--- a/dna-src/zomes/graphql/code/src/schema/post.rs
+++ b/dna-src/zomes/graphql/code/src/schema/post.rs
@@ -41,28 +41,28 @@ impl Post {
 }
 
 graphql_object!(Post: Context |&self| {
-	field id(&executor) -> ID {
+	field id() -> ID {
 		self.id.clone().into()
 	}
 
-	field creator(&executor) -> FieldResult<Person> {
+	field creator() -> FieldResult<Person> {
   		let id: String = self.retrieve_entry()?.creator.to_string();
   		Ok(Person{id: id.into()})
   	}
 
-	field type(&executor) -> FieldResult<String> {
+	field type() -> FieldResult<String> {
 		Ok(self.retrieve_entry()?.post_type)
 	}
 
-	field title(&executor) -> FieldResult<String> {
+	field title() -> FieldResult<String> {
   		Ok(self.retrieve_entry()?.title)
   	}
 
-	field details(&executor) -> FieldResult<String> {
+	field details() -> FieldResult<String> {
   		Ok(self.retrieve_entry()?.details)
   	}
 
-	field comments(&executor, first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<CommentQuerySet> {
+	field comments(first: Option<i32>, cursor: Option<ID>, order: Option<String>) -> FieldResult<CommentQuerySet> {
 
 		let result = call_cached("comments", "get_comments",
 			json!({
@@ -87,11 +87,11 @@ graphql_object!(Post: Context |&self| {
 	    })
 	}
 
-	field createdAt(&executor) -> String {
+	field createdAt() -> String {
 		"2019-01-14T07:52:22+0000".into()
 	}
 
-	field updatedAt(&executor) -> String {
+	field updatedAt() -> String {
 		"2019-01-14T07:52:22+0000".into()
 	}
 });
@@ -104,15 +104,15 @@ pub struct PostQuerySet {
 }
 
 graphql_object!(PostQuerySet: Context |&self| {
-	field total(&executor) -> i32 {
+	field total() -> i32 {
 		self.total
 	}
 
-	field hasMore(&executor) -> bool {
+	field hasMore() -> bool {
 		false
 	}
 
-	field items(&executor) -> Option<Vec<Option<Post>>> {
+	field items() -> Option<Vec<Option<Post>>> {
 		Some(self.items.iter().map(|item| Some(item.clone())).collect())
 	}
 });

--- a/schema.graphql
+++ b/schema.graphql
@@ -67,8 +67,6 @@ type MessageThread {
   participants(first: Int, cursor: ID, order: String): [Person]
   participantsTotal: Int
   messages(first: Int, cursor: ID, order: String): MessageQuerySet
-  unreadCount: Int
-  lastReadAt: String
 }
 
 type MessageQuerySet {

--- a/schema.graphql
+++ b/schema.graphql
@@ -52,9 +52,6 @@ type Comment {
   creator: Person
   post: Post
   createdAt: String
-  createdFrom: String
-  attachments(type: String): [Attachment]
-  attachmentsTotal: Int
 }
 
 type MessageThreadQuerySet {
@@ -128,7 +125,7 @@ input CommunityInput {
 
 type Mutation {
   createComment(data: CommentInput): Comment
-  createCommunity(data: CommunityInput): Membership
+  createCommunity(data: CommunityInput): Community
   createMessage(data: MessageInput): Message
   createPost(data: PostInput): Post
   findOrCreateThread(data: MessageThreadInput): MessageThread


### PR DESCRIPTION
The first test runs an introspection query on the juniper graphql implementation and compares it with the reference schema. Any non-backward-compatible changes away from the reference will cause the tests to fail.

In future any proposed changes to the schema should be done via a PR with the changes made to the schema.jsonfile. This should be reviewed by both front-end and back-end dev teams. The implementation of the queries and schema can then be updated to match the new reference and the PR merged.