### PR TITLE
Make agent1 port the default port for WS

### DIFF
--- a/conductor-config-agent1.toml
+++ b/conductor-config-agent1.toml
@@ -24,7 +24,7 @@ path = "tmp-storage"
 id = "websocket_interface"
 [interfaces.driver]
 type = "websocket"
-port = 3401
+port = 3400
 [[interfaces.instances]]
 id = "hylo-chat"
 


### PR DESCRIPTION
`holochain.hylo.com` is pointing to port 3400 for the agent by default. It'd be nice to have the first agent point to this default port or to change what we're expecting by default so that no conductor config changes are needed for basic single agent testing.