### PR TITLE
Example config with instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 .idea
 Cargo.lock
 package-lock.json
+conductor-config.toml

--- a/conductor-config-agent1.toml
+++ b/conductor-config-agent1.toml
@@ -1,5 +1,5 @@
 [[agents]]
-id = "test_agent1"
+id = "hylo_agent"
 name = "HoloTester1"
 public_address = "HcScjcgKqXC5pmfvka9DmtEJwVr548yd86UPtJGGoue9ynuikuRTN7oE5zcjgbi"
 keystore_file = "./agent1.keystore"
@@ -12,13 +12,15 @@ hash = "Qm328wyq38924y"
 [[instances]]
 id = "hylo-chat"
 dna = "chat_dna"
-agent = "test_agent1"
+agent = "hylo_agent"
 [instances.logger]
 type = "simple"
 file = "app_spec.log"
 [instances.storage]
 type = "memory"
 path = "tmp-storage"
+
+# -- WS-RPC interface to Hylo DNA
 
 [[interfaces]]
 id = "websocket_interface"
@@ -28,16 +30,27 @@ port = 3401
 [[interfaces.instances]]
 id = "hylo-chat"
 
+# # -- Hylo UI
+
+# [[ui_bundles]]
+# id = "hylo-ui"
+# root_dir = "./hylo-ui"
+# hash = "Qm000"
+
+# [[ui_interfaces]]
+# id = "hylo-interface"
+# bundle = "hylo-ui"
+# port = 8000
+
+# -- GraphiQl HTTP interface and UI
+
 [[interfaces]]
 id = "GraphiQl-http-interface"
 [interfaces.driver]
 type = "http"
-port = 4001
+port = 4002
 [[interfaces.instances]]
 id = "hylo-chat"
-
-
-#===================================================================
 
 [[ui_bundles]]
 id = "main"
@@ -47,17 +60,25 @@ hash = "Qm000"
 [[ui_interfaces]]
 id = "ui-interface"
 bundle = "main"
-port = 5001
+port = 5002
 dna_interface = "GraphiQl-http-interface"
+
+# -- Networking
+
+[network]
+n3h_path = "/path/to/n3h"
+n3h_persistence_path = "/tmp"
+n3h_log_level = "t"
+bootstrap_nodes = []
+# * For testing with a persistent n3h bootstrap node:
+# bootstrap_nodes = [
+#   "wss://holo-dna.hylo.com:38474/?a=HcSci3mbfjh4nqtj7rQArggU7Ijrv6dbqT9fwpTmUQsthb84DQDPgTvayg6iuti"
+# ]
+
+# -- Logger (settings below will disable most logging)
 
 # [logger]
 # type="debug"
 # [[logger.rules.rules]]
 # exclude=true
 # pattern=".*"
-
-[network]
-n3h_path = "/path/to/n3h"
-n3h_persistence_path = "/tmp"
-bootstrap_nodes = []
-n3h_log_level = "t"

--- a/conductor-config-agent2.toml
+++ b/conductor-config-agent2.toml
@@ -1,5 +1,5 @@
 [[agents]]
-id = "test_agent2"
+id = "hylo_agent"
 name = "HoloTester2"
 public_address = "HcScidPSdAT43q9qirJwt5rHJYjjsvougV3jgSBwdJujszw3bBu5Mktr74Rgnea"
 keystore_file = "./agent2.keystore"
@@ -12,13 +12,15 @@ hash = "Qm328wyq38924y"
 [[instances]]
 id = "hylo-chat"
 dna = "chat_dna"
-agent = "test_agent2"
+agent = "hylo_agent"
 [instances.logger]
 type = "simple"
 file = "app_spec.log"
 [instances.storage]
 type = "memory"
 path = "tmp-storage"
+
+# -- WS-RPC interface to Hylo DNA
 
 [[interfaces]]
 id = "websocket_interface"
@@ -28,6 +30,20 @@ port = 3402
 [[interfaces.instances]]
 id = "hylo-chat"
 
+# # -- Hylo UI
+
+# [[ui_bundles]]
+# id = "hylo-ui"
+# root_dir = "./hylo-ui"
+# hash = "Qm000"
+
+# [[ui_interfaces]]
+# id = "hylo-interface"
+# bundle = "hylo-ui"
+# port = 8000
+
+# -- GraphiQl HTTP interface and UI
+
 [[interfaces]]
 id = "GraphiQl-http-interface"
 [interfaces.driver]
@@ -35,9 +51,6 @@ type = "http"
 port = 4002
 [[interfaces.instances]]
 id = "hylo-chat"
-
-
-#===================================================================
 
 [[ui_bundles]]
 id = "main"
@@ -50,14 +63,22 @@ bundle = "main"
 port = 5002
 dna_interface = "GraphiQl-http-interface"
 
+# -- Networking
+
+[network]
+n3h_path = "/path/to/n3h"
+n3h_persistence_path = "/tmp"
+n3h_log_level = "t"
+bootstrap_nodes = []
+# * For testing with a persistent n3h bootstrap node:
+# bootstrap_nodes = [
+#   "wss://holo-dna.hylo.com:38474/?a=HcSci3mbfjh4nqtj7rQArggU7Ijrv6dbqT9fwpTmUQsthb84DQDPgTvayg6iuti"
+# ]
+
+# -- Logger (settings below will disable most logging)
+
 # [logger]
 # type="debug"
 # [[logger.rules.rules]]
 # exclude=true
 # pattern=".*"
-
-[network]
-n3h_path = "/path/to/n3h"
-n3h_persistence_path = "/tmp"
-bootstrap_nodes = []
-n3h_log_level = "t"

--- a/example-conductor-config.toml
+++ b/example-conductor-config.toml
@@ -1,8 +1,17 @@
+# * Copy this file to conductor-config.toml and generate a unique agent key
+#   for your instance of Hylo DNA:
+#
+#    1. Run `hc keygen`
+#    2. Copy the public address hash and copy it into public_address below
+#    3. Point the path noted in "Keystore written to:" to keystore_file below
+
+# -- Hylo DNA registration and instance config
+
 [[agents]]
 id = "hylo_agent"
-name = "HoloTester3"
-public_address = "HcScIpNoy4Q5Xw76ggYWeMRcH5yxyitijRaREZHF9P6dau76aJygYS67G8Fcydi"
-keystore_file = "./agent3.keystore"
+name = "Holochain for Hylo agent"
+public_address = ""
+keystore_file = ""
 
 [[dnas]]
 id = "chat_dna"
@@ -26,7 +35,7 @@ path = "tmp-storage"
 id = "websocket_interface"
 [interfaces.driver]
 type = "websocket"
-port = 3403
+port = 3400
 [[interfaces.instances]]
 id = "hylo-chat"
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "holo-hylo-dna",
   "version": "0.0.3",
   "scripts": {
+    "start": "holochain -c ./conductor-config.toml",
     "start:agent1": "holochain -c ./conductor-config-agent1.toml",
     "start:agent2": "holochain -c ./conductor-config-agent2.toml",
     "start:agent3": "holochain -c ./conductor-config-agent3.toml",


### PR DESCRIPTION
The intention here is that we generate once our own keys (`hc keygen -n`), add back a `yarn start` task in `package.json` which points to `conductor-config.toml`. Then put our own key reference in `conductor-config.toml` and add those files to `.gitignore`. 

This will give us a local agent setup that will be persistent and default (and can have the WS interface on port 3400 which Hylo is expecting).

Adding a `conductor-config.toml.default` which has notes in it making clear how to generate an agent key and rename the file.

Seems sensible to me.